### PR TITLE
Updated .overlay

### DIFF
--- a/boards/shields/zest_battery_lipo/zest_battery_lipo.overlay
+++ b/boards/shields/zest_battery_lipo/zest_battery_lipo.overlay
@@ -16,8 +16,11 @@
 		rshunt = <20>;
 		capacity = <800>;
 		empty-voltage = <3050>;
+		voltage-thresholds = <3600 4250>;
+		current-thresholds = <(-800) 800>;
+		temperature-thresholds = <2732 3181>;
 		external-thermistor1;
 		external-thermistor2;
-		alert-gpios = <&sixtron_connector DIO1 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
+		alert-gpios = <&sixtron_connector DIO1 (GPIO_ACTIVE_LOW | GPIO_OPEN_DRAIN)>;
 	};
 };


### PR DESCRIPTION
Updated .overlay according to sixtron_bus.overlay from  sample's [driver](https://github.com/catie-aq/zephyr_maxim-max17201).